### PR TITLE
Resolve issue with name too short

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,7 @@ resource "azurerm_log_analytics_solution" "solution_aks_development" {
 # ACR
 
 resource "azurerm_container_registry" "acr" {
-  name                     = "${var.prefix}"
+  name                     = "${var.prefix}acr"
   resource_group_name      = "${azurerm_resource_group.rg_aks_development.name}"
   location                 = "${azurerm_resource_group.rg_aks_development.location}"
   sku                      = "Premium"


### PR DESCRIPTION
When using short prefix of 4 chars it will result in a plan error. A simple fix is to append the letters "acr" after the prefix to meet the minimum 5 chars name requirement for the resource.